### PR TITLE
Correct loading state when GET /user/me returns null data

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -31,7 +31,7 @@ class App extends Component {
 
   componentDidMount() {
     api.getUserInfo().then(data => {
-      this.setState({ isLoading: false, isAuthed: !!data.user.username });
+      this.setState({ isLoading: false, isAuthed: !!data.user });
     });
   }
 


### PR DESCRIPTION
Use data.user instead of data.user.username, in case /user/me returns a null user (client has not authenticated and needs a JWT)